### PR TITLE
add mockredispy to allow running without redis

### DIFF
--- a/mock_s3.py
+++ b/mock_s3.py
@@ -7,7 +7,10 @@ from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 from SocketServer import ThreadingMixIn
 
 from jinja2 import Environment, PackageLoader
-from redis import StrictRedis
+try:
+    from redis import StrictRedis
+except:
+    from mockredis.client import MockRedis as StrictRedis
 
 from actions import get_acl, get_item, list_buckets, ls_bucket
 from file_store import FileStore
@@ -155,7 +158,11 @@ if __name__ == '__main__':
                         help='Pull non-existent keys from aws.')
     args = parser.parse_args()
 
-    redis_client = StrictRedis()
+    try:
+        redis_client = StrictRedis(strict=True)
+    except:
+        redis_client = StrictRedis()
+
 
     server = ThreadedHTTPServer((args.hostname, args.port), S3Handler)
     server.set_file_store(FileStore(args.root, redis_client))


### PR DESCRIPTION
This is a simple little change that tries to use mockredispy from https://github.com/locationlabs/mockredis if redis isn't installed.  It will first check if it can import redis.StrictRedis, if it can't, it will import mockredis.MockRedis as StrictRedis.

Below, when it is trying to use StrictRedis, it will first try using it as if it were MockRedis, which would fail if redis.StrictRedis were imported.  Then it will try it as if it were redis.StrictRedis, which will succeed.

This allows one to not have to install a redis server in order to use mock_s3.

I'm not sure exactly how requirements.txt should be formatted to say that you can either use redis or mockredispy.  Each time you start mock_s3 with MockRedis, you will need to re-create the buckets you need as in the tests/create.py because MockRedis is not persistent.
