### PR TITLE
Fix DuplicateSectionError

### DIFF
--- a/mock_s3/file_store.py
+++ b/mock_s3/file_store.py
@@ -246,7 +246,8 @@ class FileStore(object):
                 'filename': filename,
                 'size': size,
             }
-        config.add_section('metadata')
+        if not config.has_section('metadata'):
+            config.add_section('metadata')
         config.set('metadata', 'size', metadata['size'])
         config.set('metadata', 'md5', metadata['md5'])
         config.set('metadata', 'filename', metadata['filename'])


### PR DESCRIPTION
This fixes DuplicateSectionError when a fake object is stored (written to) more than once.