### PR TITLE
Fix minor bugs in headers and responses

### DIFF
--- a/mock_s3/actions.py
+++ b/mock_s3/actions.py
@@ -92,6 +92,7 @@ def get_item(handler, bucket_name, item_name):
             finish = content_length - 1
         bytes_to_read = finish - start + 1
         handler.send_header('Content-Range', 'bytes %s-%s/%s' % (start, finish, content_length))
+        handler.send_header('Content-Length', '%s' % (finish - start + 1))
         handler.end_headers()
         item.io.seek(start)
         handler.wfile.write(item.io.read(bytes_to_read))

--- a/mock_s3/actions.py
+++ b/mock_s3/actions.py
@@ -85,7 +85,7 @@ def get_item(handler, bucket_name, item_name):
         handler.send_header('Last-Modified', last_modified)
         handler.send_header('Etag', item.md5)
         handler.send_header('Accept-Ranges', 'bytes')
-        range_ = handler.headers['bytes'].split('=')[1]
+        range_ = handler.headers['range'].split('=')[1]
         start = int(range_.split('-')[0])
         finish = int(range_.split('-')[1])
         if finish == 0:

--- a/mock_s3/xml_templates.py
+++ b/mock_s3/xml_templates.py
@@ -15,15 +15,16 @@ buckets_bucket_xml = '''    <Bucket>
       <CreationDate>{bucket.creation_date}</CreationDate>
     </Bucket>'''
 
-bucket_query_xml = '''<?xml version='1.0' encoding='UTF-8'?>
-<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
-  <Name>{bucket_query.bucket.name}</Name>
-  <Prefix>{bucket_query.prefix}</Prefix>
-  <Marker>{bucket_query.marker}</Marker>
-  <MaxKeys>{bucket_query.max_keys}</MaxKeys>
-  <IsTruncated>false</IsTruncated>
-  {contents}
-</ListBucketResult>'''
+bucket_query_xml = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">'
+    '<Name>{bucket_query.bucket.name}</Name>'
+    '<Prefix>{bucket_query.prefix}</Prefix>'
+    '<Marker>{bucket_query.marker}</Marker>'
+    '<MaxKeys>{bucket_query.max_keys}</MaxKeys>'
+    '<IsTruncated>false</IsTruncated>'
+    '{contents}'
+    '</ListBucketResult>')
 
 bucket_query_content_xml = '''  <Contents>
     <Key>{s3_item.key}</Key>


### PR DESCRIPTION
1) When parsing `Range` header, it was looking for the wrong key in headers

```
Range: bytes=0-255
```

The header is `range`, not `bytes`. `bytes` is just part of the value.

2) APIs connecting often require Content-Length. For example, the AWS SDK for Java does Content-Length validation and without the additional header, the validation fails.

3) Remove whitespace from an XML response. Whitespace is information that shouldn't be there and a lot of parsers break when it is included. In particular, the Amazon AWS SDK for Java breaks when parsing the response with whitespaces, this piece of code sees the content as `\n\strue` and therefore breaks because it doesn't start with `true`: https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/transform/XmlResponsesSaxParser.java#L582-L594
